### PR TITLE
タブをスワイプ不可に設定&GPSとAPI周りのコードをリファクタ

### DIFF
--- a/src/api/gnaviApi.js
+++ b/src/api/gnaviApi.js
@@ -2,9 +2,12 @@ const response = 'https://api.gnavi.co.jp/RestSearchAPI/20150630/';
 const key = '0ec809ca9e26ce462ed18ddc74768cb8';
 const format = 'json';
 
+const responseWithParam = location => `${response}?keyid=${key}&format=${format}&input_coordinates_mode=2&coordinates_mode=2\
+&latitude=${location.latitude}\
+&longitude=${location.longitude}`;
+
 export function fetchRestaurantByLocation(location) {
-  return fetch(`${response}?keyid=${key}&format=${format}&input_coordinates_mode=2&coordinates_mode=2&latitude=${location.latitude}&longitude=${location.longitude}`)
+  return fetch(responseWithParam(location))
     .then(res => res.json())
-    .then(json => json.rest)
-    .catch(error => error);
+    .then(json => json.rest);
 }

--- a/src/component/HomeScreen.js
+++ b/src/component/HomeScreen.js
@@ -28,6 +28,7 @@ const Tab = TabNavigator({
     showLabel: true,
     showIcon: true,
   },
+  swipeEnabled: false,
 });
 
 class HomeScreen extends React.Component {

--- a/src/gps/LocationManager.js
+++ b/src/gps/LocationManager.js
@@ -1,5 +1,5 @@
 function getLocation() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const location = {
@@ -9,7 +9,9 @@ function getLocation() {
         resolve(location);
       },
       // TODO: error handling
-      error => console.log(error),
+      (error) => {
+        reject(error);
+      },
     );
   });
 }
@@ -20,5 +22,6 @@ async function syncLocation() {
 }
 
 export function getOnceLocation() {
-  return syncLocation().then(location => location);
+  return syncLocation()
+    .then(location => location);
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -7,13 +7,18 @@ import { getOnceLocation } from '../gps/LocationManager';
 
 function* loadRestaurantByGps() {
   yield put(setRefreshVisibility(true));
-  const location = yield call(getOnceLocation);
-  const rest = yield call(fetchRestaurantByLocation, location);
-  yield all([
-    put(updateLocation(location)),
-    put(updateRestaurant(rest)),
-    put(setRefreshVisibility(false)),
-  ]);
+  try {
+    // location
+    const location = yield call(getOnceLocation);
+    yield put(updateLocation(location));
+    // load resaurant
+    const rest = yield call(fetchRestaurantByLocation, location);
+    yield put(updateRestaurant(rest));
+  } catch (error) {
+    // TODO: error handling
+    console.log('loadRestaurantByGps', error);
+  }
+  yield put(setRefreshVisibility(false));
 }
 
 function* initLoad() {
@@ -29,7 +34,7 @@ function* initLoad() {
     }
   } catch (error) {
     // TODO: error handling
-    yield console.log(error);
+    yield console.log('initLoad', error);
   }
 }
 


### PR DESCRIPTION
## issue
- close #14 

## 概要
- Android版でもタブがスワイプできないようにしました。
- __APIのurlが長すぎてlintエラー起きてたので自分なりに修正しました。(もっといい方法あれば教えてください)__
- async functionの実装内にcatchを書くとtry/catch文でのcatchが機能しないので、削除しました。これでsaga内のcatchは返ってくるので、view側にエラーハンドリングができます
- 今まではView側へのGPSとAPIの反映はこれら全ての動作が完全に終了した時点でdispatchしていましたが、それだとAPIの初期ロード中に現在地がアフリカの海の中なのが嫌だったので取得出来次第即反映することにしました